### PR TITLE
chore: add docker compose, and add instructions for setup to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,26 @@
 Repo for the documentation website.
 
 [Reference](https://squidfunk.github.io/mkdocs-material/reference/)
+
+## Local Setup
+
+### PIP
+
+Install with pip via terminal.
+
+```
+pip install mkdocs
+mkdocs serve
+```
+If you have trouble using the mkdocs command you can try:
+```
+python -m mkdocs serve
+```
+
+### Docker Compose
+
+Ensure you have docker installed. Run the compose without detatch to get tty (terminal).
+
+```
+docker-compose up
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  mkdocs:
+    image: squidfunk/mkdocs-material
+    container_name: digital-controllers-mkdocs
+    ports:
+      - 8000:8000
+    volumes:
+      - ./:/docs
+    stdin_open: true
+    tty: true


### PR DESCRIPTION
- Add docker compose for quickstart without any python installs/config fun times.
- Copy some of the setup info from mkdocs-material.
