### PR TITLE
fix: missing newline needed for markdown list

### DIFF
--- a/docs/general-knowledge/index.md
+++ b/docs/general-knowledge/index.md
@@ -1,6 +1,7 @@
 # General Knowledge
 
 The general knowledge section contains the following information:
+
 - [Radiotelephony](./radiotelephony.md)
 - [Altimetry](./altimetry.md)
 - [Meteorology](./meteorology.md)


### PR DESCRIPTION
Only with a newline before the list is this well formed markdown.